### PR TITLE
Add support for ending db connections

### DIFF
--- a/src/schemaInterfaces.ts
+++ b/src/schemaInterfaces.ts
@@ -18,4 +18,5 @@ export interface Database {
     getTableDefinition (tableName: string, tableSchema: string): Promise<TableDefinition>
     getTableTypes (tableName: string, tableSchema: string, options: Options): Promise<TableDefinition>
     getSchemaTables (schemaName: string): Promise<string[]>
+    end (): Promise<void>
 }

--- a/src/schemaMysql.ts
+++ b/src/schemaMysql.ts
@@ -172,6 +172,18 @@ export class MysqlDatabase implements Database {
         })
     }
 
+    public async end (): Promise<void> {
+        return new Promise<void>((resolve, reject) => {
+            this.db.end(error => {
+                if (error) {
+                    reject(error)
+                } else {
+                    resolve()
+                }
+            })
+        })
+    }
+
     public getDefaultSchema (): string {
         return this.defaultSchema
     }

--- a/src/schemaPostgres.ts
+++ b/src/schemaPostgres.ts
@@ -151,6 +151,15 @@ export class PostgresDatabase implements Database {
         )
     }
 
+    public async end (): Promise<void> {
+        // As of pg-promise 6.10.3, their types dependencies are pretty bad.
+        // Here is what it should be refering to:
+        // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3e1e03d0d43d9cf569c93e27c8763e2e94a6674c/types/pg/index.d.ts#L150
+        const pool = this.db.$pool as {end (): Promise<void>}
+
+        return pool.end()
+    }
+
     getDefaultSchema (): string {
         return 'public'
     }


### PR DESCRIPTION
### What
Add support to end connections with the database and end those connections if we own them.

### Why
The process hangs to finish even though the file is already written to disk. What is happening is that the open connections to the database are preventing Node from exiting.

### How
Added `.end()` method to the `Database` interface and implemented them for the databases classes.
Then I added conditional calls to this method on `typescriptOfTable` and `typescriptOfSchema`. The condition is that we only end the connection if we have created the database instance. Otherwise we can't be sure we can end the connection.

### Results
In a quick test with postgres, generating the typescript for a one table schema:

- Before: 10.578s, 10.591s, 11.972s
- After: 0.750s, 0.637s, 0.663s